### PR TITLE
Export to a separate folder by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 __pycache__
 *.npy
 .data
+source/export/

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -949,6 +949,12 @@ class GUI:
         # Start export in seperate thread to keep UI responsive
         if len([photo for photo in self.photos if not photo.reject]) == 0:
             return
+        if not self.destination_folder:
+            self.destination_folder = "export"  # sets default export folder
+        if not os.path.exists(self.destination_folder):
+            os.makedirs(self.destination_folder)
+            print(f'Creating {self.destination_folder}')
+        
         if n_photos == 1:
             export_fn = self.export_individual
         else:
@@ -973,7 +979,7 @@ class GUI:
         self.current_photo.load(True)
         self.current_photo.process(True)
         self.update_progress(99, 'Exporting photo...')
-        filename = self.destination_folder + str(self.current_photo).split('.')[0] # removes the file extension
+        filename = os.path.join(self.destination_folder, str(self.current_photo).split('.')[0]) # removes the file extension
         self.current_photo.export(filename) # saves the photo
         self.current_photo_button.configure(state=tk.NORMAL)
         self.all_photo_button.configure(state=tk.NORMAL)
@@ -1003,7 +1009,7 @@ class GUI:
                     continue
                 if photo.use_global_settings:
                     self.apply_settings(photo, self.global_settings) # Ensures the proper settings have been applied
-                filename = self.destination_folder + str(photo).split('.')[0] # removes the file extension
+                filename = os.path.join(self.destination_folder, str(self.current_photo).split('.')[0]) # removes the file extension
                 inputs.append((photo, filename, self.terminate, RawProcessing.class_parameters))
                 if hasattr(photo, 'memory_alloc'):
                     allocated += photo.memory_alloc # tally of estimated memory requirements of each photo


### PR DESCRIPTION
If no destination folder is specified, photos are exported to the root of the source folder. Now, they are placed in a separate "source/export" folder instead, keeping the source folder clean. The export folder is also added to .gitignore.