### PR TITLE
Better white frames & Fit Aspect Ratio function

### DIFF
--- a/source/GUI.py
+++ b/source/GUI.py
@@ -63,7 +63,9 @@ class GUI:
             sat = 100,
             base_detect = 0,
             base_rgb = (255, 255, 255),
-            remove_dust = False
+            remove_dust = False,
+            frame = 0,
+            fit_aspect_ratio = 'Keep Original'
         )
 
         self.global_settings = self.default_settings.copy()
@@ -213,13 +215,13 @@ class GUI:
         export_title = ttk.Label(text='Export Settings', font=self.header_style, padding=2)
         export_frame = ttk.LabelFrame(dynamic_scroll_frame.frame, borderwidth=2, labelwidget=export_title, padding=5)
         export_frame.grid(row=9, column=0, sticky='EW')
-        export_settings_frame = ttk.Frame(export_frame)
-        export_settings_frame.pack(fill='x')
-        ComboLabel(export_settings_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
-        self.frame = ScaleEntry(export_settings_frame, 'White Frame (%):', 1, 0, 10, 'frame', global_sync=False, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['frame'])
-        ComboLabel(export_settings_frame, 'Fit Aspect Ratio:', 2, self.fit_aspect_ratios, 'fit_aspect_ratio', global_sync=False, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['fit_aspect_ratio'], width=20)
-        export_settings_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
-        
+        border_frame = ttk.Frame(export_frame)
+        self.frame = ScaleEntry(border_frame, 'White Frame (%):', 0, 0, 10, 'frame', self.widgets, global_sync=True, command=lambda widget:self.widget_changed(widget, 'update'))
+        ComboLabel(border_frame, 'Fit Aspect Ratio:', 1, self.fit_aspect_ratios, 'fit_aspect_ratio', self.widgets, global_sync=True, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update'), width=20)
+        border_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
+        filetype_frame = ttk.Frame(export_frame)
+        filetype_frame.pack(fill='x')
+        ComboLabel(filetype_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
         ttk.Label(export_frame, text='Output Destination Folder:', anchor='w').pack(fill = 'x')
         self.destination_folder_text = tk.StringVar()
         self.destination_folder_text.set('No Destination Folder Specified')

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -30,6 +30,7 @@ class GUI:
         self.in_progress = set() # keeps track photos that are in processing when first loading
         self.photo_process_values = ['RAW', 'Threshold', 'Contours', 'Histogram', 'Full Preview']
         self.filetypes = ['TIFF', 'PNG', 'JPG'] # Export File Types
+        self.fit_aspect_ratios = ['Keep Original', '16:9 (Landscape)', '3:2 (Landscape)', '4:3 (Landscape)', '5:4 (Landscape)', '1:1 (Square)', '4:5 (Portrait)', '3:4 (Portrait)', '2:3 (Portrait)', '9:16 (Portrait)']
         self.destination_folder = ''
         self.allowable_image_filetypes = [
             ('RAW files', '*.DNG *.CR2 *.CR3 *.NEF *.ARW *.RAF *.ERF *.GPR *.RAW *.CRW *.dng *.cr2 *.cr3 *.nef *.arw *.raf *.erf *.grp *.raw *.crw'),
@@ -216,6 +217,9 @@ class GUI:
         export_settings_frame.pack(fill='x')
         ComboLabel(export_settings_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
         self.frame = ScaleEntry(export_settings_frame, 'White Frame (%):', 1, 0, 10, 'frame', global_sync=False, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['frame'])
+        ComboLabel(export_settings_frame, 'Fit Aspect Ratio:', 2, self.fit_aspect_ratios, 'fit_aspect_ratio', global_sync=False, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['fit_aspect_ratio'])
+        export_settings_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
+        
         ttk.Label(export_frame, text='Output Destination Folder:', anchor='w').pack(fill = 'x')
         self.destination_folder_text = tk.StringVar()
         self.destination_folder_text.set('No Destination Folder Specified')

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -217,7 +217,7 @@ class GUI:
         export_settings_frame.pack(fill='x')
         ComboLabel(export_settings_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
         self.frame = ScaleEntry(export_settings_frame, 'White Frame (%):', 1, 0, 10, 'frame', global_sync=False, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['frame'])
-        ComboLabel(export_settings_frame, 'Fit Aspect Ratio:', 2, self.fit_aspect_ratios, 'fit_aspect_ratio', global_sync=False, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['fit_aspect_ratio'])
+        ComboLabel(export_settings_frame, 'Fit Aspect Ratio:', 2, self.fit_aspect_ratios, 'fit_aspect_ratio', global_sync=False, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['fit_aspect_ratio'], width=20)
         export_settings_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
         
         ttk.Label(export_frame, text='Output Destination Folder:', anchor='w').pack(fill = 'x')

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -63,9 +63,7 @@ class GUI:
             sat = 100,
             base_detect = 0,
             base_rgb = (255, 255, 255),
-            remove_dust = False,
-            frame = 0,
-            fit_aspect_ratio = 'Keep Original'
+            remove_dust = False
         )
 
         self.global_settings = self.default_settings.copy()
@@ -215,13 +213,13 @@ class GUI:
         export_title = ttk.Label(text='Export Settings', font=self.header_style, padding=2)
         export_frame = ttk.LabelFrame(dynamic_scroll_frame.frame, borderwidth=2, labelwidget=export_title, padding=5)
         export_frame.grid(row=9, column=0, sticky='EW')
-        border_frame = ttk.Frame(export_frame)
-        self.frame = ScaleEntry(border_frame, 'White Frame (%):', 0, 0, 10, 'frame', self.widgets, global_sync=True, command=lambda widget:self.widget_changed(widget, 'update'))
-        ComboLabel(border_frame, 'Fit Aspect Ratio:', 1, self.fit_aspect_ratios, 'fit_aspect_ratio', self.widgets, global_sync=True, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update'), width=20)
-        border_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
-        filetype_frame = ttk.Frame(export_frame)
-        filetype_frame.pack(fill='x')
-        ComboLabel(filetype_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
+        export_settings_frame = ttk.Frame(export_frame)
+        export_settings_frame.pack(fill='x')
+        ComboLabel(export_settings_frame, 'Export File Type:', 0, self.filetypes, 'filetype', global_sync=False, output_list=self.filetypes, command=lambda widget:self.widget_changed(widget, 'skip', False), default_value=RawProcessing.default_parameters['filetype'])
+        self.frame = ScaleEntry(export_settings_frame, 'White Frame (%):', 1, 0, 10, 'frame', global_sync=False, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['frame'])
+        ComboLabel(export_settings_frame, 'Fit Aspect Ratio:', 2, self.fit_aspect_ratios, 'fit_aspect_ratio', global_sync=False, output_list=self.fit_aspect_ratios, command=lambda widget:self.widget_changed(widget, 'update', False), default_value=RawProcessing.default_parameters['fit_aspect_ratio'], width=20)
+        export_settings_frame.pack(fill='x', pady=(0, 15)) # adds some spacing
+        
         ttk.Label(export_frame, text='Output Destination Folder:', anchor='w').pack(fill = 'x')
         self.destination_folder_text = tk.StringVar()
         self.destination_folder_text.set('No Destination Folder Specified')

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -40,7 +40,7 @@ class RawProcessing:
         fit_aspect_ratio = 'Keep Original'
     )
     class_parameters = default_parameters.copy()
-    advanced_attrs = [key for key in default_parameters.keys() if key not in ('filetype', 'frame')] # list of keys for advanced settings, except for keys that should not be saved
+    advanced_attrs = [key for key in default_parameters.keys() if key not in ('filetype', 'frame', 'fit_aspect_ratio')] # list of keys for advanced settings, except for keys that should not be saved
     processing_parameters = ('dark_threshold','light_threshold','border_crop','flip','rotation','film_type','white_point','black_point','gamma','shadows','highlights','temp','tint','sat','reject','base_detect','base_rgb','remove_dust')
     
     def __init__(self, file_directory, default_settings, global_settings, config_path):

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -17,7 +17,6 @@ class RawProcessing:
         max_proxy_size = 2000, # Max dimension of height + width to increase processing speed (only for previews)
         histogram_plt_size = (1600, 2400, 3), # Dimensions of the histogram
         hist_bg_colour = (25, 25, 25), # sets the background colour of the histogram
-        frame = 0, # adds white frame to final photo
         jpg_quality = 90, # from 0-100
         tiff_compression = 8, # defines the tiff compression algorithm
         dm_alg = 2, # demosaicing algorithm
@@ -36,12 +35,11 @@ class RawProcessing:
         max_dust_area = 15,
         dust_iter = 5,
         picker_radius = 0.5,
-        filetype = 'JPG',
-        fit_aspect_ratio = 'Keep Original'
+        filetype = 'JPG'
     )
     class_parameters = default_parameters.copy()
-    advanced_attrs = [key for key in default_parameters.keys() if key not in ('filetype', 'frame', 'fit_aspect_ratio')] # list of keys for advanced settings, except for keys that should not be saved
-    processing_parameters = ('dark_threshold','light_threshold','border_crop','flip','rotation','film_type','white_point','black_point','gamma','shadows','highlights','temp','tint','sat','reject','base_detect','base_rgb','remove_dust')
+    advanced_attrs = [key for key in default_parameters.keys() if key not in ('filetype')] # list of keys for advanced settings, except for keys that should not be saved
+    processing_parameters = ('dark_threshold','light_threshold','border_crop','flip','rotation','film_type','white_point','black_point','gamma','shadows','highlights','temp','tint','sat','reject','base_detect','base_rgb','remove_dust','frame','fit_aspect_ratio')
     
     def __init__(self, file_directory, default_settings, global_settings, config_path):
         # file_directory: the name of the RAW file to be processed
@@ -124,15 +122,16 @@ class RawProcessing:
         self.FileReadError = False
         self.memory_alloc = self.RAW_IMG.nbytes * 4 * 12 # estimation of memory requirements based on the size of the image
 
-    def get_IMG(self, output=None):
+    def get_IMG(self, output=None, as_array=False):
         # Returns the converted image at different stages of the process, based on desired output
         if self.FileReadError: # Return nothing when file could not be read
             return
         match output:
             case 'RAW': # return RAW image
-                img = cv2.convertScaleAbs(self.RAW_IMG, alpha=(255.0/65535.0))
+                img = self.rotate(self.RAW_IMG) # apply rotation to image
             case 'Threshold': # return threshold image
                 img = self.thresh
+                img = self.rotate(img) # apply rotation to image
             case 'Contours': # generate contour image, then return it
                 thresh_img = np.uint8(cv2.cvtColor(self.thresh, cv2.COLOR_GRAY2BGR) / 2)
                 thresh_img[:,:,2] = 0 # sets colour of threshold image
@@ -181,6 +180,7 @@ class RawProcessing:
                     cv2.drawContours(img,[box],0,(0,255,255), int(border_width * 0.75)) # original crop
                     cv2.drawContours(img, self.largest_contour, -1, (0,255,255), int(border_width * .75)) # largest contour
                     cv2.drawContours(img,[extra_crop_box],0,(0,255,0), int(border_width)) # extra border crop
+                img = self.rotate(img) # apply rotation to image
             case 'Histogram': # returns histogram of preview image
                 img = self.draw_histogram(self.IMG)
                 img = np.flip(img, 0)
@@ -190,12 +190,15 @@ class RawProcessing:
                 img = self.IMG
                 if self.remove_dust:
                     img = self.fill_dust(img, self.dust_mask)
+                img = self.rotate(img) # apply rotation to image
                 img = self.add_frame(img) # add decorative white frame
+        if as_array:
+            return img
+        else:
+            if img.dtype == 'uint16':
                 img = cv2.convertScaleAbs(img, alpha=(255.0/65535.0))
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) # Convert back to RGB
-        if output != 'Histogram':
-            img = self.rotate(img) # apply rotation to image
-        return Image.fromarray(img) # convert image to tkinter-friendly image
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) # Convert back to RGB
+            return Image.fromarray(img) # convert image to tkinter-friendly image
         
     def __str__(self):
         # returns file name when str() is called on photo
@@ -206,10 +209,7 @@ class RawProcessing:
         # filename is a string containing the directory and file name with the file extension
         if not hasattr(self, 'IMG'):
             return
-        img = self.IMG
-        if self.remove_dust:
-            img = self.fill_dust(img, self.dust_mask)
-        img = self.add_frame(self.rotate(img)) # add decorative white frame
+        img = self.get_IMG(as_array=True)
         filename = f"{filename}.{self.class_parameters['filetype']}"
         match self.class_parameters['filetype']:
             case 'JPG':
@@ -619,17 +619,17 @@ class RawProcessing:
         return hist_plot
     
     def add_frame(self, img):
-        if self.class_parameters['frame'] == 0:
-            if self.class_parameters['fit_aspect_ratio'] == 'Keep Original':
-                return img # skip if aspect ratio and frame have default values
+        # adds frame to image border
+        if self.frame == 0 and self.fit_aspect_ratio == 'Keep Original':
+            return img # skip if aspect ratio and frame have default values
 
-        frame_size = max(1, int(min(img.shape[:2]) * self.class_parameters['frame'] / 100)) # at least one pixel wide frame
+        frame_size = max(1, int(min(img.shape[:2]) * self.frame / 100)) # at least one pixel wide frame
         new_shape = (img.shape[0] + 2 * frame_size, img.shape[1] + 2 * frame_size) + img.shape[2:]
         frame_img = np.ones(new_shape, dtype=img.dtype) * 65535
         frame_img[frame_size:-frame_size, frame_size:-frame_size] = img # center image inside frame
 
-        if self.class_parameters['fit_aspect_ratio'] != 'Keep Original': # fit image to aspect ratio
-            target_w, target_h = map(int, self.class_parameters['fit_aspect_ratio'].split(' ', 1)[0].split(':')) # parse 'W:H (text)' to W, H
+        if self.fit_aspect_ratio != 'Keep Original': # fit image to aspect ratio
+            target_w, target_h = map(int, self.fit_aspect_ratio.split(' ', 1)[0].split(':')) # parse 'W:H (text)' to W, H
             target_ratio = target_w / target_h
             current_ratio = frame_img.shape[1] / frame_img.shape[0]
             if current_ratio > target_ratio: # image is wider than target aspect ratio

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -621,14 +621,11 @@ class RawProcessing:
         # adds decorative white border to the outside of picture
         if self.class_parameters['frame'] == 0:
             return img
-        scale_factor = self.class_parameters['frame'] / 50 + 1
-        new_shape = np.array(img.shape)
-        new_shape[0] *= scale_factor
-        new_shape[1] *= scale_factor
-        new_shape.astype(np.int_)
-        frame_img = np.ones(new_shape, np.uint16) * 65535
-        x_offset, y_offset = int(img.shape[1] * self.class_parameters['frame'] / 100), int(img.shape[0] * self.class_parameters['frame'] / 100)
-        frame_img[y_offset:y_offset+img.shape[0], x_offset:x_offset+img.shape[1]] = img
+        frame_size = min(int(img.shape[1] * self.class_parameters['frame'] / 100),
+                         int(img.shape[0] * self.class_parameters['frame'] / 100))
+        new_shape = (img.shape[0] + 2 * frame_size, img.shape[1] + 2 * frame_size, img.shape[2])
+        frame_img = np.ones(new_shape, dtype=img.dtype) * 65535
+        frame_img[frame_size:frame_size + img.shape[0], frame_size:frame_size + img.shape[1]] = img
         return frame_img
 
     def clear_memory(self):


### PR DESCRIPTION
White frames from this tool looked unusual. After checking r/analog, I found only about 1 in 10 photos had uneven frames, most had uniform thickness. The solution was using the same thickness for a better look.

Also I added "Fit Aspect Ratio" function for 3:4, 5:4, 1:1 and other ratios, I think it turned out great.

<img src="https://github.com/user-attachments/assets/ed0d7ac4-214c-432b-b2fb-e4c85dee1ae4" alt="Image" width="380"/>

![image](https://github.com/user-attachments/assets/ee122a0c-0e95-4578-a90d-d90823c9ce75)

White Frame: 2%  &  Fit Aspect Ratio: 4:3 
