### PR TITLE
Implement EXIF functions as bare minimum working example for JPEGs

### DIFF
--- a/source/CustomWidgets.py
+++ b/source/CustomWidgets.py
@@ -256,7 +256,7 @@ class ComboLabel:
 class MultiEntryLabel:
     # defines label with a given number of numerical entries
     # useful for when the modified parameter is an iterable
-    # Has 4 methods that can be called: get(), set(), hide().
+    # Has 4 methods that can be called: get(), set(), hide(), show().
     # When the widget is interacted with, it will call the method passed into the command argument, and pass the widget itself as a parameter.
     # Must be placed in grid
     def __init__(self, master, text: str, row: int, from_: int|float, to: int|float, num_entries: int, default_values: Iterable=None, key: str=None, widget_dictionary: dict=None, global_sync: bool=True, is_float=False, increment: int|float=1, width=20, command: Callable=lambda x:None):

--- a/source/CustomWidgets.py
+++ b/source/CustomWidgets.py
@@ -253,6 +253,42 @@ class ComboLabel:
         self.label.grid(row=self.row, column=0, sticky=tk.E)
         self.combobox.grid(row=self.row, column=1, sticky=tk.W, padx=2, columnspan=2)
 
+class EntryLabel:
+    # defines a label with an entry text box
+    # useful for when information should be entered as a text value
+    # Has 4 methods that can be called: get(), set(), hide(), show().
+    # Must be placed in grid
+    def __init__(self, master, text: str, row: int, key: str=None, widget_dictionary: dict=None, placeholder: str=None):
+        self.row = row
+        self.key = key
+        if widget_dictionary is not None and key is not None:
+            widget_dictionary[self.key] = self # adding widget to provided dictionary
+
+        self.value = tk.StringVar(master)
+
+        self.label = ttk.Label(master, text=text)
+        self.entry_make = tk.Entry(master, textvariable=self.value, placeholder=placeholder)
+
+        self.show()
+
+    def get(self):
+        # Returns the text stored in the entry text box
+        return self.value.get()
+
+    def set(self, value: str):
+        # Updates widgets to given value
+        self.value.set(value)
+
+    def hide(self):
+        # Hides the widget
+        self.label.grid_forget()
+        self.entry_frame.grid_forget()
+
+    def show(self):
+        # Shows the widget
+        self.label.grid(row=self.row, column=0, sticky=tk.E)
+        self.entry_make.grid(row=self.row, column=1, sticky='new', padx=2, pady=2)
+
 class MultiEntryLabel:
     # defines label with a given number of numerical entries
     # useful for when the modified parameter is an iterable

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -11,7 +11,7 @@ import multiprocessing
 from typing import Literal
 
 #custom classes
-from CustomWidgets import ScrollFrame, ScaleEntry, CheckLabel, ComboLabel, MultiEntryLabel
+from CustomWidgets import ScrollFrame, ScaleEntry, CheckLabel, ComboLabel, EntryLabel, MultiEntryLabel
 from RawProcessing import RawProcessing
 
 #logging
@@ -91,6 +91,7 @@ class GUI:
         self.editmenu.add_command(label='Reset to Default Settings', command=self.reset_settings)
         self.editmenu.add_separator()
         self.editmenu.add_command(label='Advanced Settings...', command=self.advanced_dialog)
+        self.editmenu.add_command(label='Add EXIF data', command=self.add_exifdata)
         menubar.add_cascade(label='Edit', menu=self.editmenu)
         self.master.config(menu=menubar)
 
@@ -444,6 +445,67 @@ class GUI:
         ttk.Button(buttonFrame, text='Cancel', command=quit).pack(side=tk.RIGHT, padx=2, pady=5, anchor='sw')
         ttk.Button(buttonFrame, text='Save', command=save_settings).pack(side=tk.RIGHT, padx=2, pady=5, anchor='sw')
         ttk.Button(buttonFrame, text='Reset to Default', command=reset, width=17).pack(side=tk.RIGHT, padx=2, pady=5, anchor='sw')
+
+        # Centres pop-up window over self.master window
+        top.update_idletasks()
+        x = self.master.winfo_x() + int((self.master.winfo_width()/2) - (top.winfo_width()/2))
+        y = self.master.winfo_y() + int((self.master.winfo_height()/2) - (top.winfo_height()/2))
+        top.geometry('+%d+%d' % (x, y))
+
+    def add_exifdata(self):
+        def save_settings():
+            # applies the values stored in the widgets to raw processing
+            for widget in widget_dict.values():
+                if widget.key in RawProcessing.exif_parameters:
+                    RawProcessing.exif_parameters[widget.key] = widget.get()
+            
+            quit()
+            
+
+        def quit():
+            self.master.attributes('-topmost', 0)
+            top.destroy()
+
+        top = tk.Toplevel(self.master)
+        top.transient(self.master)
+        top.title('Add EXIF data')
+        top.grab_set()
+        top.bind('<Button>', lambda event: event.widget.focus_set())
+        top.resizable(False, False)
+        top.focus_set()
+        top.protocol('WM_DELETE_WINDOW', quit)
+
+        mainFrame = ttk.Frame(top, padding=10)
+        mainFrame.pack(fill='x')
+
+        firstColumn = ttk.Frame(mainFrame, padding=2)
+        firstColumn.grid(row=0, column=0, sticky='n')
+
+        widget_dict = {}
+        
+        label_camera_information = ttk.Label(top, text='Camera Information', font=self.header_style, padding=2)
+        labelframe_camera_information = ttk.LabelFrame(firstColumn, borderwidth=2, labelwidget=label_camera_information, padding=5)
+        labelframe_camera_information.pack(fill='x', expand=True)
+
+        EntryLabel(labelframe_camera_information, 'Camera make', 0, 'camera_make', widget_dict)
+        EntryLabel(labelframe_camera_information, 'Camera model', 1, 'camera_model', widget_dict)
+
+        label_lens_information = ttk.Label(top, text='Lens Information', font=self.header_style, padding=2)
+        labelframe_lens_information = ttk.LabelFrame(firstColumn, borderwidth=2, labelwidget=label_lens_information, padding=5)
+        labelframe_lens_information.pack(fill='x', expand=True)
+
+        EntryLabel(labelframe_lens_information, 'Lens make', 0, 'lens_make', widget_dict)
+        EntryLabel(labelframe_lens_information, 'Lens model', 1, 'lens_model', widget_dict)
+
+        label_datetime_information = ttk.Label(top, text='Date and Time', font=self.header_style, padding=2)
+        labelframe_datetime_information = ttk.LabelFrame(firstColumn, borderwidth=2, labelwidget=label_datetime_information, padding=5)
+        labelframe_datetime_information.pack(fill='x', expand=True)
+
+        EntryLabel(labelframe_datetime_information, 'Date Time Original', 0, 'date_time_original', widget_dict, 'YYYY:MM:DD hh:mm:ss')
+
+        buttonFrame = ttk.Frame(mainFrame)
+        buttonFrame.grid(row=1, column=0, columnspan=2, sticky='e')
+        ttk.Button(buttonFrame, text='Save', command=save_settings).pack(side=tk.LEFT, padx=2, pady=5, anchor='sw')
 
         # Centres pop-up window over self.master window
         top.update_idletasks()

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -4,7 +4,6 @@ import sys
 from tkinter import ttk,  filedialog, messagebox, colorchooser
 import tkinter as tk
 from PIL import ImageTk
-import rawpy
 import threading
 import numpy as np 
 import cv2

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -3,7 +3,8 @@ import cv2
 import numpy as np
 from PIL import Image
 import matplotlib.colors
-import os 
+import os
+import piexif
 
 import logging
 

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -45,6 +45,14 @@ class RawProcessing:
     advanced_attrs = [key for key in default_parameters.keys() if key not in ('filetype', 'frame', 'fit_aspect_ratio')] # list of keys for advanced settings, except for keys that should not be saved
     processing_parameters = ('dark_threshold','light_threshold','border_crop','flip','rotation','film_type','white_point','black_point','gamma','shadows','highlights','temp','tint','sat','reject','base_detect','base_rgb','remove_dust')
     
+    exif_parameters = dict(
+        camera_make = '',
+        camera_model = '',
+        lens_make = '',
+        lens_model = '',
+        date_time_original = ''
+    )
+
     def __init__(self, file_directory, default_settings, global_settings, config_path):
         # file_directory: the name of the RAW file to be processed
         # Instance Variables
@@ -198,6 +206,37 @@ class RawProcessing:
         # returns file name when str() is called on photo
         return os.path.basename(self.file_directory)
     
+    def get_exif_bytes(self):
+        # Builds a valid exif data structure based on the exif parameters and the given image as bytes
+        # Returns bytes containing the exif data structure for images
+        zeroth_ifd = {
+            piexif.ImageIFD.Make: self.exif_parameters['camera_make'],
+            piexif.ImageIFD.Model: self.exif_parameters['camera_model'],
+            piexif.ImageIFD.Software: "Film Scan Converter"
+        }
+        exif_ifd = {
+            piexif.ExifIFD.DateTimeOriginal: self.exif_parameters['date_time_original'],
+            piexif.ExifIFD.LensMake: self.exif_parameters['lens_make'],
+            piexif.ExifIFD.LensModel: self.exif_parameters['lens_model'],
+        }
+        gps_ifd = {
+            # placeholder for further development
+        }
+        first_ifd = {
+            # placeholder for further development
+        }
+
+        # piexif expects this dict structure
+        exif_dict = {
+            '0th':zeroth_ifd,
+            'Exif':exif_ifd,
+            'GPS':gps_ifd,
+            '1st':first_ifd,
+            'thumbnail': None
+        }
+
+        return piexif.dump(exif_dict)
+
     def export(self, filename):
         # Saves final image to disk.
         # filename is a string containing the directory and file name with the file extension

--- a/source/RawProcessing.py
+++ b/source/RawProcessing.py
@@ -246,8 +246,11 @@ class RawProcessing:
         filename = f"{filename}.{self.class_parameters['filetype']}"
         match self.class_parameters['filetype']:
             case 'JPG':
-                quality = [cv2.IMWRITE_JPEG_QUALITY, self.class_parameters['jpg_quality']]
-                cv2.imwrite(filename, cv2.convertScaleAbs(img, alpha=(255.0/65535.0)), quality) # Must convert to 8-bit image before exporting as JPG
+                img_8bit = cv2.convertScaleAbs(img, alpha=(255.0/65535.0)) # Must convert to 8-bit image before exporting as JPG
+                img_pil = Image.fromarray(cv2.cvtColor(img_8bit, cv2.COLOR_RGB2BGR))
+                exif = self.get_exif_bytes()
+
+                img_pil.save(filename, format='JPEG', quality=self.class_parameters['jpg_quality'], exif=exif)
             case 'TIFF':
                 quality = [cv2.IMWRITE_TIFF_COMPRESSION, self.class_parameters['tiff_compression']]
                 cv2.imwrite(filename, img, quality)

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -6,3 +6,4 @@ opencv_python_headless==4.10.0.84
 Pillow==11.1.0
 psutil==6.1.1
 rawpy==0.24.0
+piexif==1.1.3


### PR DESCRIPTION
Regarding our discussion [here](https://github.com/kaimonmok/Film-Scan-Converter/discussions/30), I worked on a minimum working example on how to implement the EXIF data.

Basically, there is a new submenu under **Edit**, opening a dialog for passing EXIF data to the application. As of now, I only implemented _Camera make_, _Camera model_, _Lens make_, _Lens model_ and the _Date Time Original_-field.
Implementing other fields is fairly simple.

For this, I also added a new custom widget, **EntryLabel**, which consists of a label and a corresponding textbox.
Currently missing is the ability to show the already entered EXIF data when re-opening the dialog.

The feature is only implemented for JPEG exports.