### PR TITLE
Add support for Olympus/OM Systems RAW files

### DIFF
--- a/source/GUI.py
+++ b/source/GUI.py
@@ -33,7 +33,7 @@ class GUI:
         self.fit_aspect_ratios = ['Keep Original', '16:9 (Landscape)', '3:2 (Landscape)', '4:3 (Landscape)', '5:4 (Landscape)', '1:1 (Square)', '4:5 (Portrait)', '3:4 (Portrait)', '2:3 (Portrait)', '9:16 (Portrait)']
         self.destination_folder = ''
         self.allowable_image_filetypes = [
-            ('RAW files', '*.DNG *.CR2 *.CR3 *.NEF *.ARW *.RAF *.ERF *.GPR *.RAW *.CRW *.dng *.cr2 *.cr3 *.nef *.arw *.raf *.erf *.grp *.raw *.crw'),
+            ('RAW files', '*.DNG *.CR2 *.CR3 *.NEF *.ARW *.RAF *.ORF *.ORI *.ERF *.GPR *.RAW *.CRW *.dng *.cr2 *.cr3 *.nef *.arw *.raf *.orf *.ori *.erf *.grp *.raw *.crw'),
             ('Image files', '*.PNG *.JPG *.JPEG *.BMP *.TIFF *.TIF *.png *.jpg *.jpeg *.bmp *.tiff *.tif')
             ]
         self.header_style = ('Segoe UI', 10, 'normal') # Defines font for section headers


### PR DESCRIPTION
Since the underlying rawpy/LibRAW library supports Olympus/OM Systems raw files, all that is needed is to add them to the allowable_image_filetypes list. 

I tested it out with both Olympus and OM-Systems raw files and using both ORF and ORI file types. ORF are the normal raw files, but if you shoot in "high res" mode it will produce an ORI file which is just the regular resolution version.