### PR TITLE
ART Integration and CLI args

### DIFF
--- a/ART-Commands/film_scan_converter_directory.sh
+++ b/ART-Commands/film_scan_converter_directory.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Python interpreter to use
+PYTHON={path to your Film Scan Converter VENV  python executable}
+
+# directory where Film-Scan-Converter is located
+FSC_DIR={path to Film Scan Converter root dir}
+
+"${PYTHON}" "${FSC_DIR}/source/Film Scan Converter.pyw" "-d" "$1" "-o" "$1/converted" &

--- a/ART-Commands/film_scan_converter_directory.txt
+++ b/ART-Commands/film_scan_converter_directory.txt
@@ -1,0 +1,4 @@
+[ART UserCommand]
+Label=Film Scan Converter
+Command=./film_scan_converter_directory.sh
+FileType=directory

--- a/ART-Commands/film_scan_converter_files.sh
+++ b/ART-Commands/film_scan_converter_files.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Python interpreter to use
+PYTHON={path to your Film Scan Converter VENV python executable}
+
+# directory where Film-Scan-Converter is located
+FSC_DIR={path to Film Scan Converter root dir}
+
+f=""
+
+for file in "$@"; do
+	f="${f} ${file}"
+done
+
+"${PYTHON}" "${FSC_DIR}/source/Film Scan Converter.pyw" "-f" "$f" "-o" "$1/converted" &

--- a/ART-Commands/film_scan_converter_files.sh
+++ b/ART-Commands/film_scan_converter_files.sh
@@ -9,7 +9,13 @@ FSC_DIR={path to Film Scan Converter root dir}
 f=""
 
 for file in "$@"; do
-	f="${f} ${file}"
+	if [[ f -eq "" ]]; then
+		f=${file}
+	else
+		f="${f}, ${file}"
+	fi
 done
 
-"${PYTHON}" "${FSC_DIR}/source/Film Scan Converter.pyw" "-f" "$f" "-o" "$1/converted" &
+d="$(dirname "$1")/converted"
+
+"${PYTHON}" "${FSC_DIR}/source/Film Scan Converter.pyw" "-f" "$f" "-o" "$d" &

--- a/ART-Commands/film_scan_converter_files.txt
+++ b/ART-Commands/film_scan_converter_files.txt
@@ -1,0 +1,3 @@
+[ART UserCommand]
+Label=Film Scan Converter
+Command=./film_scan_converter_files.sh

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ Quick Links:
 
 Developer documentation and contribution guidelines are available in the [docs/developer-guide.md](docs/development/index.md) file.
 
+## ART Integration
+
+Film scan converter can be integrated into [Art Raw Editor](https://artraweditor.github.io) to provide quick and convenient access to opening full folders, individuals files and multiple selected files. The documentation on how to install art and how to use the integration is located in [docs/how-to-add-to-ART.md](docs/how-to-add-to-ART.md).
+
 ## Contributing
 
 If you're reading this, thanks for helping me take this project further beyond what I can accomplish on my own. The analog community has long been deprived of a free, intuitive, and standalone film inversion application, and your contribution will help film photography be more accessible to many more people.
 
-Please continue reading in the [contributing](docs/development/contributing.md) chapter.
+Please continue reading in the [contributing](docs/contributing.md) chapter.

--- a/docs/how-to-add-to-ART.md
+++ b/docs/how-to-add-to-ART.md
@@ -1,0 +1,10 @@
+# How to add to ART
+1. Follow the steps in `installation.md` section `Manual Installation in Python venv`
+2. Copy all files in `ART-Commands` to the `usercommands` directory described in [ART User Commands](https://artraweditor.github.io/Usercommands).
+3. Open `film_scan_converter_directory.sh` and `film_scan_converter_files.sh` for editing
+4. Replace `{path to your Film Scan Converter VENV  python executable}` with the path to your VENV python binary e.g. `/home/user/dev/Film-Scan-Converter/source/venv/bin/python`
+5. Replace `{path to Film Scan Converter root dir}` with the path to Film Scan Converter, e.g. `/home/user/dev/Film-Scan-Converter`
+6. Launch ART, you should now have additional options for selecting folders and files for conversion
+
+## Video Intructions
+A video on how to install and use Film Scan Converter in ART is available [here](https://www.youtube.com/watch?v=8uGc7bAjnsI)

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -47,7 +47,7 @@ There are 3 command line variables that can be passed in when opening Film Scan 
 - Output Directory: `-o path/to/folder` this will set the output directory to the passed in path  
   Example use: `python "Film Scan Converter.pyw" -o /home/user/Pictures/scans/output`
 
-- Files: `-f path/to/file.tiff` this will open one or multiple files on open, files are separated with a space.  
-  Example use: `python "Film Scan Converter.pyw" -f "/home/user/Pictures/scans/scan_1.tiff /home/user/Pictures/scans/scan_2.tiff"`
+- Files: `-f path/to/file.tiff` this will open one or multiple files on open, files are separated with a comma (`,`).  
+  Example use: `python "Film Scan Converter.pyw" -f "/home/user/Pictures/scans/scan_1.tiff, /home/user/Pictures/scans/scan_2.tiff"`
 
 Multiple variables can be passed at once, so `python "Film Scan Converter.pyw" -d /home/user/Pictures/scans -o /home/user/Pictures/scans/output` is a valid set of options.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -38,3 +38,16 @@ By default, each colour channel will be equalized such that the darkest point is
 - If the white balance is wrong, it can be corrected by manually adjusting the temperature and tint values, or by using the white balance picker and clicking on any neutral gray portion of the image.
 - If sprocket holes are desired in the final image, they will need to be masked out for the equalization calculation. This can be done by going to Edit -> Advanced Settings -> EQ Ignore Borders %, and increasing the height parameter until the sprocket holes are masked. For 35mm film, a value of 15% usually works. To visualize this masking, it is displayed in the "Contours" view as a red border within the cropped region, as shown below:  
 ![image](./images/41ef16e7-def5-4a36-9d6d-d7c685c5b1ab.png)
+
+## Command Line Variables
+There are 3 command line variables that can be passed in when opening Film Scan Converter, these are:
+- Directory: `-d path/to/folder` this will open all compatible files in the given folder on open.  
+  Example use: `python "Film Scan Converter.pyw" -d /home/user/Pictures/scans`
+
+- Output Directory: `-o path/to/folder` this will set the output directory to the passed in path  
+  Example use: `python "Film Scan Converter.pyw" -o /home/user/Pictures/scans/output`
+
+- Files: `-f path/to/file.tiff` this will open one or multiple files on open, files are separated with a space.  
+  Example use: `python "Film Scan Converter.pyw" -f "/home/user/Pictures/scans/scan_1.tiff /home/user/Pictures/scans/scan_2.tiff"`
+
+Multiple variables can be passed at once, so `python "Film Scan Converter.pyw" -d /home/user/Pictures/scans -o /home/user/Pictures/scans/output` is a valid set of options.

--- a/source/Film Scan Converter.pyw
+++ b/source/Film Scan Converter.pyw
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         root = tk.Tk()
         root.iconbitmap(default=resource_path(datafile))
 
-    window = GUI(root)
+    window = GUI(root, opts.output_directory)
 
     # If a directory argument has been passed then load it after the mainloop starts
     if opts.directory is not None:

--- a/source/Film Scan Converter.pyw
+++ b/source/Film Scan Converter.pyw
@@ -3,14 +3,25 @@ import multiprocessing
 import ctypes
 import os
 import sys
-import logging 
+import logging
+import argparse
 
 #Custom classes
 from GUI import GUI
 
+
+def getopts():
+    p = argparse.ArgumentParser()
+    p.add_argument("-d", "--directory", help="load this directory on open")
+    p.add_argument("-o", "--output_directory", help="set an output directory")
+    p.add_argument("-f", "--file", help="open one or more files on launch")
+    return p.parse_args()
+
+
 logger = logging.getLogger(__name__)
 FORMAT = '%(asctime)s:::%(levelname)s:::%(message)s'
 logging.basicConfig(filename='logfile.log', level=logging.DEBUG, format=FORMAT)
+opts = getopts()
    
 if __name__ == '__main__':
     # Main function
@@ -39,4 +50,17 @@ if __name__ == '__main__':
         root.iconbitmap(default=resource_path(datafile))
 
     window = GUI(root)
+
+    # If a directory argument has been passed then load it after the mainloop starts
+    if opts.directory is not None:
+        root.after(0, window.resize_UI)
+        root.after(0, window.load_all_from_path, opts.directory)
+
+    # If a file argument has been passed and a directory argument has not then load
+    # them after mainloop starts
+    if (opts.file is not None) and (opts.directory is None):
+        filenames = opts.file.split()
+        root.after(0, window.resize_UI)
+        root.after(0, window.import_from_filenames, filenames)
+
     root.mainloop()

--- a/source/Film Scan Converter.pyw
+++ b/source/Film Scan Converter.pyw
@@ -12,9 +12,9 @@ from GUI import GUI
 
 def getopts():
     p = argparse.ArgumentParser()
-    p.add_argument("-d", "--directory", help="load this directory on open")
-    p.add_argument("-o", "--output_directory", help="set an output directory")
-    p.add_argument("-f", "--file", help="open one or more files on launch")
+    p.add_argument('-d', '--directory', help='load this directory on open')
+    p.add_argument('-o', '--output_directory', help='set an output directory')
+    p.add_argument('-f', '--file', help='open one or more files on launch')
     return p.parse_args()
 
 

--- a/source/Film Scan Converter.pyw
+++ b/source/Film Scan Converter.pyw
@@ -59,7 +59,8 @@ if __name__ == '__main__':
     # If a file argument has been passed and a directory argument has not then load
     # them after mainloop starts
     if (opts.file is not None) and (opts.directory is None):
-        filenames = opts.file.split()
+        filenames = opts.file.split(',')        
+        filenames[:] = [name.strip() for name in filenames if os.path.isfile(name.strip())]
         root.after(0, window.resize_UI)
         root.after(0, window.import_from_filenames, filenames)
 

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -25,7 +25,7 @@ FORMAT = '%(asctime)s:::%(levelname)s:::%(message)s'
 logging.basicConfig(filename='logfile.log', level=logging.DEBUG, format=FORMAT)
 
 class GUI:
-    def __init__(self, master):
+    def __init__(self, master, output_directory=None):
         # Initialize Variables
         self.config_path = self._check_and_create_conf_folder()
         self.photos = []
@@ -308,6 +308,9 @@ class GUI:
         for widget in self.widgets.values():
             if widget.key in self.default_settings:
                 widget.set(self.default_settings[widget.key]) # initializes widgets with default settings
+
+        if output_directory != None:
+            self.set_destination_folder(output_directory)
 
     def load_all_from_path(self, pathname):
         # Load all compatible files from the given path
@@ -992,8 +995,14 @@ class GUI:
         destination_folder = filedialog.askdirectory() + '/' # opens dialog to choose folder
         if len(destination_folder) <= 1: # no input is given
             return
+            
+        self.set_destination_folder(destination_folder)
+
+    def set_destination_folder(self, destination_folder):
         self.destination_folder = destination_folder
-        self.destination_folder_text.set(self.destination_folder) # display destination folder in GUI
+        self.destination_folder_text.set(
+            self.destination_folder
+        )  # display destination folder in GUI
 
     def export(self, n_photos=1):
         # Start export in seperate thread to keep UI responsive

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -533,7 +533,7 @@ class GUI:
         self.update_progress(20, f'Initializing {str(total)} photos...')
         
         for i, filename in enumerate(filenames):
-            print(f'Loding file: {filename}')
+            print(f'Loading file: {filename}')
             photo = RawProcessing(
                 file_directory=filename,
                 default_settings=self.default_settings,

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -10,6 +10,8 @@ import numpy as np
 import cv2
 import multiprocessing
 from typing import Literal
+from os.path import dirname
+import glob
 
 #custom classes
 from CustomWidgets import ScrollFrame, ScaleEntry, CheckLabel, ComboLabel, MultiEntryLabel
@@ -174,7 +176,7 @@ class GUI:
         if getattr(sys, 'frozen', False):
             picker = tk.PhotoImage(file=os.path.join(sys._MEIPASS, 'dropper.png')).subsample(15,15)
         else:
-            picker = tk.PhotoImage(file=os.path.join('assets', 'dropper.png')).subsample(15,15)
+            picker = tk.PhotoImage(file=os.path.join(dirname(__file__), "assets/dropper.png")).subsample(15,15)
         colour_title = ttk.Label(text='Colour Adjustment', font=self.header_style, padding=2)
         self.colourFrame = ttk.LabelFrame(dynamic_scroll_frame.frame, borderwidth=2, labelwidget=colour_title, padding=5)
         colour_controls = ttk.Frame(self.colourFrame)
@@ -306,6 +308,21 @@ class GUI:
         for widget in self.widgets.values():
             if widget.key in self.default_settings:
                 widget.set(self.default_settings[widget.key]) # initializes widgets with default settings
+
+    def load_all_from_path(self, pathname):
+        # Load all compatible files from the given path
+        print(f"Loading path: {pathname}")
+        extensions = self.allowable_image_filetypes[0][1].split()
+        extensions.extend(self.allowable_image_filetypes[1][1].split())
+        files = []
+
+        for extension in extensions:
+            files.extend(glob.glob(os.path.join(pathname, extension)))
+
+        files = remove_duplicate_strings(files)
+
+        if len(files) > 0:
+            self.import_from_filenames(files)
     
     def _check_and_create_conf_folder(self) -> str:
         '''
@@ -498,32 +515,51 @@ class GUI:
         if len(filenames) == 0:
             return # if user clicks 'cancel', abort operation
         
-        self.show_progress('Initializing import...') # display progress opening
+        self.import_from_filenames(filenames)
+
+    def import_from_filenames(self, filenames):
+        # Import all files from the given string list
+        self.show_progress("Initializing import...")  # display progress opening
         self.import_button.configure(state=tk.DISABLED)
-        self.filemenu.entryconfigure('Import...', state=tk.DISABLED)
-        
+        self.filemenu.entryconfigure("Import...", state=tk.DISABLED)
+
         total = len(filenames)
         self.photos = []
         photo_names = []
-        
-        self.update_progress(20, f'Initializing {str(total)} photos...')
-        for i, filename in enumerate(filenames):
-            photo = RawProcessing(file_directory=filename, default_settings=self.default_settings, global_settings=self.global_settings, config_path=self.config_path)
-            self.photos.append(photo)
-            photo_names.append(f'{str(i + 1)}. {str(photo)}')
-        
-        self.update_progress(80, 'Configuring GUI...')
-        self.photoCombo.configure(values=photo_names) # configures dropdown to include list of photos
-        self.photoCombo.current(0) # select the first photo to display
 
-        self.update_progress(90, 'Loading photo...')
-        self.load_IMG() # configure GUI to display the first photo
+        self.update_progress(20, f"Initializing {str(total)} photos...")
+        
+        for i, filename in enumerate(filenames):
+            print(f"Loding file: {filename}")
+            photo = RawProcessing(
+                file_directory=filename,
+                default_settings=self.default_settings,
+                global_settings=self.global_settings,
+                config_path=self.config_path,
+            )
+            self.photos.append(photo)
+            photo_names.append(f"{str(i + 1)}. {str(photo)}")
+
+        self.update_progress(80, "Configuring GUI...")
+        
+        self.photoCombo.configure(
+            values=photo_names
+        )  # configures dropdown to include list of photos
+
+        self.photoCombo.current(0)  # select the first photo to display
+
+        self.update_progress(90, "Loading photo...")
+        self.load_IMG()  # configure GUI to display the first photo
         self.update_progress(99)
         self.import_button.configure(state=tk.NORMAL)
-        self.filemenu.entryconfigure('Import...', state=tk.NORMAL)
+        self.filemenu.entryconfigure("Import...", state=tk.NORMAL)
         self.update_UI()
-        if self.glob_check.get() and self.global_settings != self.default_settings: # check if global settings are different from default on import
-            self.unsaved = True # if it is the default, then it doesn't need to be saved
+        if (
+            self.glob_check.get() and self.global_settings != self.default_settings
+        ):  # check if global settings are different from default on import
+            self.unsaved = (
+                True  # if it is the default, then it doesn't need to be saved
+            )
         else:
             self.unsaved = False
         self.hide_progress()
@@ -539,6 +575,7 @@ class GUI:
 
         if len(self.photos) == 0:
             return
+
         photo_index = self.photoCombo.current()
         self.current_photo = self.photos[photo_index]
         self.glob_check.set(self.current_photo.use_global_settings)
@@ -1243,3 +1280,16 @@ class GUI:
                 photo.clear_memory()
                 return False
         return error
+
+def remove_duplicate_strings(strings):
+    # Remove duplicate strings from a list ignoring case
+    seen = set()
+    result = []
+
+    for s in strings:
+        lower = s.lower()
+        if lower not in seen:
+            seen.add(lower)
+            result.append(s)
+
+    return result

--- a/source/GUI.py
+++ b/source/GUI.py
@@ -176,7 +176,7 @@ class GUI:
         if getattr(sys, 'frozen', False):
             picker = tk.PhotoImage(file=os.path.join(sys._MEIPASS, 'dropper.png')).subsample(15,15)
         else:
-            picker = tk.PhotoImage(file=os.path.join(dirname(__file__), "assets/dropper.png")).subsample(15,15)
+            picker = tk.PhotoImage(file=os.path.join(dirname(__file__), 'assets/dropper.png')).subsample(15,15)
         colour_title = ttk.Label(text='Colour Adjustment', font=self.header_style, padding=2)
         self.colourFrame = ttk.LabelFrame(dynamic_scroll_frame.frame, borderwidth=2, labelwidget=colour_title, padding=5)
         colour_controls = ttk.Frame(self.colourFrame)
@@ -314,7 +314,7 @@ class GUI:
 
     def load_all_from_path(self, pathname):
         # Load all compatible files from the given path
-        print(f"Loading path: {pathname}")
+        print(f'Loading path: {pathname}')
         extensions = self.allowable_image_filetypes[0][1].split()
         extensions.extend(self.allowable_image_filetypes[1][1].split())
         files = []
@@ -522,18 +522,18 @@ class GUI:
 
     def import_from_filenames(self, filenames):
         # Import all files from the given string list
-        self.show_progress("Initializing import...")  # display progress opening
+        self.show_progress('Initializing import...')  # display progress opening
         self.import_button.configure(state=tk.DISABLED)
-        self.filemenu.entryconfigure("Import...", state=tk.DISABLED)
+        self.filemenu.entryconfigure('Import...', state=tk.DISABLED)
 
         total = len(filenames)
         self.photos = []
         photo_names = []
 
-        self.update_progress(20, f"Initializing {str(total)} photos...")
+        self.update_progress(20, f'Initializing {str(total)} photos...')
         
         for i, filename in enumerate(filenames):
-            print(f"Loding file: {filename}")
+            print(f'Loding file: {filename}')
             photo = RawProcessing(
                 file_directory=filename,
                 default_settings=self.default_settings,
@@ -541,9 +541,9 @@ class GUI:
                 config_path=self.config_path,
             )
             self.photos.append(photo)
-            photo_names.append(f"{str(i + 1)}. {str(photo)}")
+            photo_names.append(f'{str(i + 1)}. {str(photo)}')
 
-        self.update_progress(80, "Configuring GUI...")
+        self.update_progress(80, 'Configuring GUI...')
         
         self.photoCombo.configure(
             values=photo_names
@@ -551,11 +551,11 @@ class GUI:
 
         self.photoCombo.current(0)  # select the first photo to display
 
-        self.update_progress(90, "Loading photo...")
+        self.update_progress(90, 'Loading photo...')
         self.load_IMG()  # configure GUI to display the first photo
         self.update_progress(99)
         self.import_button.configure(state=tk.NORMAL)
-        self.filemenu.entryconfigure("Import...", state=tk.NORMAL)
+        self.filemenu.entryconfigure('Import...', state=tk.NORMAL)
         self.update_UI()
         if (
             self.glob_check.get() and self.global_settings != self.default_settings


### PR DESCRIPTION
This does a few things:  
1. Adds `-d`, `-f`, and `-o` CLI arguments for opening a directory, file(s) and setting an output directory on open 
2. Breaks up the import and select folder functions to support this new functionality 
3. Adds a new ART-Commands folder, which is scripts for integrating FSC into ART 
4. Fixes an issue with loading the dropper asset when launching FSC in linux from a folder that is not the root of source 
5. Updates the readmes to cover these new commands, and installation instructions for the scripts 
6. Fixed a dead link in the Readme to the contibutors section

Video of the new integration can be seen here: https://www.youtube.com/watch?v=8uGc7bAjnsI